### PR TITLE
chore: supports vite ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "vite": "^2.9.0 || ^3.0.0"
+    "vite": "^2.9.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.25.2",


### PR DESCRIPTION
vite ^4.0.0 以上版本的依赖警告

Warning about dependencies with vite ^4.0.0 and above

```
 - WARN  Issues with peer dependencies found
   - ✕ unmet peer vite@"^2.9.0 || ^3.0.0": found 4.0.4
 ```